### PR TITLE
#patch fix: only add imports for necessary mods when they arent in scope

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,38 @@
+use std::collections::VecDeque;
+use syn::UseTree;
+
+fn recurse_use_item<'a>(use_tree: &'a UseTree, tokens: &mut VecDeque<&str>) -> Option<&'a UseTree> {
+    let curr_ident = tokens.pop_front().unwrap_or_default();
+    match use_tree {
+        UseTree::Path(use_stmt_third) => {
+            if use_stmt_third.ident == curr_ident {
+                recurse_use_item(&*use_stmt_third.tree, tokens)
+            } else {
+                None
+            }
+        }
+        UseTree::Name(ref use_stmt_third) => {
+            if use_stmt_third.ident == curr_ident {
+                Some(use_tree)
+            } else {
+                None
+            }
+        }
+        UseTree::Rename(_) => None,
+        UseTree::Glob(_) => None,
+        UseTree::Group(ref use_stmt_third) => {
+            for item in &use_stmt_third.items {
+                tokens.push_front(curr_ident);
+                if let Some(group_tree) = recurse_use_item(item, tokens) {
+                    return Some(group_tree);
+                }
+            }
+            None
+        }
+    }
+}
+
+pub fn traverse_use_item<'a>(use_tree: &'a UseTree, tokens: Vec<&str>) -> Option<&'a UseTree> {
+    let mut tokens = VecDeque::from(tokens);
+    recurse_use_item(use_tree, &mut tokens)
+}

--- a/tests/mixed_all.rs
+++ b/tests/mixed_all.rs
@@ -1,0 +1,85 @@
+#![allow(unused_imports)]
+use test_env_helpers::*;
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod before_after {
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod once_import {
+    use std::sync::Once;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod sync_glob_import {
+    use std::sync::*;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod atomic_glob_import {
+    use std::sync::atomic::*;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod atomic_usize_import {
+    use std::sync::atomic::AtomicUsize;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod atomic_ordering_import {
+    use std::sync::atomic::Ordering;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_all]
+#[after_all]
+#[cfg(test)]
+mod other_atomic_import {
+    use std::sync::atomic::AtomicBool;
+    fn before_all() {}
+    fn after_all() {}
+
+    #[test]
+    fn test_macro() {}
+}

--- a/tests/mixed_each.rs
+++ b/tests/mixed_each.rs
@@ -1,0 +1,85 @@
+#![allow(unused_imports)]
+use test_env_helpers::*;
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod before_after {
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod once_import {
+    use std::sync::Once;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod sync_glob_import {
+    use std::sync::*;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod atomic_glob_import {
+    use std::sync::atomic::*;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod atomic_usize_import {
+    use std::sync::atomic::AtomicUsize;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod atomic_ordering_import {
+    use std::sync::atomic::Ordering;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}
+
+#[before_each]
+#[after_each]
+#[cfg(test)]
+mod other_atomic_import {
+    use std::sync::atomic::AtomicBool;
+    fn before_each() {}
+    fn after_each() {}
+
+    #[test]
+    fn test_macro() {}
+}


### PR DESCRIPTION
i noticed that the before_all and after_all functions were only working in the tests because i was importing some mods i was using inside the tests.
this adds some handling to only add them when they aren't in scope