### PR TITLE
after_all fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,10 @@ use crate::utils::traverse_use_item;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote, Item, Stmt};
+use syn::Stmt;
+use syn::Item;
+use syn::parse_quote;
+use syn::parse_macro_input;
 
 /// Will run the code in the matching `after_all` function exactly once when all of the tests have
 /// run. This works by counting the number of `#[test]` attributes and decrementing a counter at
@@ -113,11 +116,16 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                     });
                 }
             };
-
+            let resume: Stmt = parse_quote! {
+                if let Err(err) = result {
+                    panic::resume_unwind(err);
+                }
+            };
             let mut count: usize = 0;
             let mut has_once: bool = false;
             let mut has_atomic_usize: bool = false;
             let mut has_ordering: bool = false;
+            let mut has_panic: bool = false;
 
             let mut e: Vec<Item> = everything_else
                 .into_iter()
@@ -135,10 +143,13 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                             .count();
                         if test_count > 0 {
                             count += test_count;
-                            let mut stmts = vec![];
-                            stmts.append(&mut f.block.stmts);
-                            stmts.push(after_all_if.clone());
-                            f.block.stmts = stmts;
+                            let block = f.block.clone();
+                            let catch_unwind: Stmt = parse_quote! {
+                                let result = panic::catch_unwind(|| {
+                                    #block
+                                });
+                            };
+                            f.block.stmts = vec![catch_unwind, after_all_if.clone(), resume.clone()];
                             Item::Fn(f)
                         } else {
                             Item::Fn(f)
@@ -165,6 +176,13 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                         {
                             has_ordering = true;
                         }
+                        if traverse_use_item(
+                            &use_stmt.tree,
+                            vec!["std", "panic"],
+                        )
+                        .is_some() {
+                            has_panic = true;
+                        }
                         Item::Use(use_stmt)
                     }
                     el => el,
@@ -179,6 +197,9 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
             );
             let use_ordering: Item = parse_quote!(
                 use std::sync::atomic::Ordering;
+            );
+            let use_panic: Item = parse_quote!(
+                use std::panic;
             );
             let static_once: Item = parse_quote!(
                 static AFTER_ALL: Once = Once::new();
@@ -197,6 +218,9 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
             }
             if !has_ordering {
                 once_content.push(use_ordering);
+            }
+            if !has_panic {
+                once_content.push(use_panic);
             }
             once_content.append(&mut vec![static_once, static_count]);
             once_content.append(&mut e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,8 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                     _ => unreachable!(),
                 }
             };
-            let inc_count: Stmt = parse_quote!(
-                REMAINING_TESTS.fetch_sub(1, Ordering::SeqCst);
-            );
             let after_all_if: Stmt = parse_quote! {
-                if REMAINING_TESTS.load(Ordering::SeqCst) <= 0{
+                if REMAINING_TESTS.fetch_sub(1, Ordering::SeqCst) == 1 {
                     AFTER_ALL.call_once(|| {
                         #after_all_fn_block
                     });
@@ -138,7 +135,7 @@ pub fn after_all(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                             .count();
                         if test_count > 0 {
                             count += test_count;
-                            let mut stmts = vec![inc_count.clone()];
+                            let mut stmts = vec![];
                             stmts.append(&mut f.block.stmts);
                             stmts.push(after_all_if.clone());
                             f.block.stmts = stmts;

--- a/tests/after.rs
+++ b/tests/after.rs
@@ -4,6 +4,8 @@ use test_env_helpers::*;
 #[cfg(test)]
 mod after_all {
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
     use test_case::test_case;
     use tokio;
 
@@ -17,6 +19,8 @@ mod after_all {
     #[test_case(1)]
     #[test_case(2)]
     fn async_test_macro_2(_: u8) {
+        //emulates slow test
+        thread::sleep(Duration::from_millis(5));
         T.fetch_add(3, Ordering::SeqCst);
     }
     #[tokio::test]

--- a/tests/after.rs
+++ b/tests/after.rs
@@ -11,7 +11,7 @@ mod after_all {
 
     static T: AtomicUsize = AtomicUsize::new(0);
     fn after_all() {
-        assert_eq!(T.load(Ordering::SeqCst), 9);
+        assert_eq!(T.load(Ordering::SeqCst), 10);
     }
 
     #[test]
@@ -23,9 +23,17 @@ mod after_all {
         thread::sleep(Duration::from_millis(5));
         T.fetch_add(3, Ordering::SeqCst);
     }
+
     #[tokio::test]
     async fn async_test_macro() {
         T.fetch_add(3, Ordering::SeqCst);
+    }
+
+    #[test]
+    #[should_panic]
+    fn failing_test() {
+        T.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(0, 1);
     }
 }
 


### PR DESCRIPTION
This PR does 2 things:
**1. fix execution of after_all block**
before: after_all block executed right after the test start, regardless if it was finished or not
now: after_all block executes after all tests finished

test wasn't correct, test cases was executing faster than after_all block.
If we emulate slow test case, test will start to fail without the fix

**2. execute after_all even after panic of any/all tests**

used the https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
and https://doc.rust-lang.org/std/panic/fn.resume_unwind.html
it will keep the error the same